### PR TITLE
Dynamic IE Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM maven:3.5-jdk-8-alpine
 RUN apk add --no-cache git
+RUN apk add --no-cache screen
 RUN mkdir -p /app/N3CMedTagger
 COPY . /app/N3CMedTagger
 RUN mkdir -p /app/work
@@ -29,11 +30,10 @@ EXPOSE 8080:8080
 
 WORKDIR /app/N3CMedTagger
 
-RUN nohup bash -c "java -jar /app/MedTaggerREST/UIMA-REST-SERVER.jar -Dserver.port=8080 &"
 RUN rm -r /app/work
 
 RUN mvn clean install -DskipTests
 
 EXPOSE 80:80
-CMD ["mvn", "spring-boot:run"]
+CMD ["./docker_run.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN cp /app/N3CMedTagger/src/main/resources/uima-stream-server-conf.json /app/Me
 EXPOSE 8080:8080
 
 WORKDIR /app/N3CMedTagger
+RUN chmod +X docker_run.sh
 
 RUN rm -r /app/work
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN git clone https://github.com/OHNLP/UIMA-Stream-Server
 WORKDIR /app/work/UIMA-Stream-Server
 RUN mvn clean install -DskipTests -P EXECUTABLE
 RUN mkdir -p /app/MedTaggerREST
-COPY ./UIMA-Server-REST/target/UIMA-REST-SERVER.jar /app/MedTaggerREST/UIMA-REST-SERVER.jar
+COPY /app/work/UIMA-Stream-Server/UIMA-Server-REST/target/UIMA-REST-SERVER.jar /app/MedTaggerREST/UIMA-REST-SERVER.jar
 RUN mkdir -p /app/MedTaggerREST/libs
 RUN mkdir -p /app/MedTaggerREST/plugins
 WORKDIR /app/work/
@@ -20,7 +20,7 @@ COPY /app/work/MedTagger/MedTagger.jar /app/MedTaggerREST/libs
 RUN git clone https://github.com/OHNLP/MedTaggerRESTPlugin.git
 WORKDIR /app/work/MedTaggerRESTPlugin
 RUN mvn clean install -DskipTests
-COPY ./target/MedTaggerRESTPlugin.jar /app/MedTaggerREST/plugins/MedTaggerRESTPlugin.jar
+COPY /app/work/MedTaggerRESTPlugin/target/MedTaggerRESTPlugin.jar /app/MedTaggerREST/plugins/MedTaggerRESTPlugin.jar
 COPY /app/N3CMedTagger/src/main/resources/uima-stream-server-conf.json /app/MedTaggerREST/medtagger_rest_config.json
 
 EXPOSE 8080:8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3.5-jdk-8-alpine
 RUN mkdir -p /app/N3CMedTagger
-RUN cp -r . /app/N3CMedTagger
+COPY . /app/N3CMedTagger
 RUN mkdir -p /app/work
 
 WORKDIR /app/work
@@ -9,18 +9,18 @@ RUN git clone https://github.com/OHNLP/UIMA-Stream-Server
 WORKDIR /app/work/UIMA-Stream-Server
 RUN mvn clean install -DskipTests -P EXECUTABLE
 RUN mkdir -p /app/MedTaggerREST
-RUN cp UIMA-Server-REST/target/UIMA-REST-SERVER.jar /app/MedTaggerREST/UIMA-REST-SERVER.jar
+COPY UIMA-Server-REST/target/UIMA-REST-SERVER.jar /app/MedTaggerREST/UIMA-REST-SERVER.jar
 RUN mkdir -p /app/MedTaggerREST/libs
 RUN mkdir -p /app/MedTaggerREST/plugins
 WORKDIR /app/work/
 RUN wget -O MedTagger.zip https://github.com/OHNLP/MedTagger/releases/download/v1.0.9/MedTagger.zip
 RUN unzip MedTagger.zip
-RUN cp /app/work/MedTagger/MedTagger.jar /app/MedTaggerREST/libs
+COPY /app/work/MedTagger/MedTagger.jar /app/MedTaggerREST/libs
 RUN git clone https://github.com/OHNLP/MedTaggerRESTPlugin.git
 WORKDIR /app/work/MedTaggerRESTPlugin
 RUN mvn clean install -DskipTests
-RUN cp target/MedTaggerRESTPlugin.jar /app/MedTaggerREST/plugins/MedTaggerRESTPlugin.jar
-RUN cp /app/N3CMedTagger/src/main/resources/uima-stream-server-conf.json /app/MedTaggerREST/medtagger_rest_config.json
+COPY target/MedTaggerRESTPlugin.jar /app/MedTaggerREST/plugins/MedTaggerRESTPlugin.jar
+COPY /app/N3CMedTagger/src/main/resources/uima-stream-server-conf.json /app/MedTaggerREST/medtagger_rest_config.json
 
 EXPOSE 8080:8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ EXPOSE 8080:8080
 
 WORKDIR /app/N3CMedTagger
 
-RUN -d java -jar /app/MedTaggerREST/UIMA-REST-SERVER.jar -Dserver.port=8080
+RUN nohup java -jar /app/MedTaggerREST/UIMA-REST-SERVER.jar -Dserver.port=8080
 RUN rm -r /app/work
 
 RUN mvn clean install -DskipTests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,33 @@
 FROM maven:3.5-jdk-8-alpine
-RUN mkdir -p /app/N3CMedTagger \
-    cp -r . /app/N3CMedTagger \
-    mkdir -p /app/work
+RUN mkdir -p /app/N3CMedTagger
+RUN cp -r . /app/N3CMedTagger
+RUN mkdir -p /app/work
 
 WORKDIR /app/work
 
-RUN git clone https://github.com/OHNLP/UIMA-Stream-Server \
-    cd /app/work/UIMA-Stream-Server \
-    mvn clean install -DskipTests -P EXECUTABLE \
-    mkdir -p /app/MedTaggerREST \
-    cp UIMA-Server-REST/target/UIMA-REST-SERVER.jar /app/MedTaggerREST/UIMA-REST-SERVER.jar \
-    mkdir -p /app/MedTaggerREST/libs \
-    mkdir -p /app/MedTaggerREST/plugins\
-    cd /app/work/ \
-    wget -O MedTagger.zip https://github.com/OHNLP/MedTagger/releases/download/v1.0.9/MedTagger.zip \
-    unzip MedTagger.zip \
-    cp /app/work/MedTagger/MedTagger.jar /app/MedTaggerREST/libs \
-    git clone https://github.com/OHNLP/MedTaggerRESTPlugin.git \
-    cd MedTaggerRESTPlugin \
-    mvn clean install -DskipTests \
-    cp target/MedTaggerRESTPlugin.jar /app/MedTaggerREST/plugins/MedTaggerRESTPlugin.jar \
-    cp /app/N3CMedTagger/src/main/resources/uima-stream-server-conf.json /app/MedTaggerREST/medtagger_rest_config.json
+RUN git clone https://github.com/OHNLP/UIMA-Stream-Server
+WORKDIR /app/work/UIMA-Stream-Server
+RUN mvn clean install -DskipTests -P EXECUTABLE
+RUN mkdir -p /app/MedTaggerREST
+RUN cp UIMA-Server-REST/target/UIMA-REST-SERVER.jar /app/MedTaggerREST/UIMA-REST-SERVER.jar
+RUN mkdir -p /app/MedTaggerREST/libs
+RUN mkdir -p /app/MedTaggerREST/plugins
+WORKDIR /app/work/
+RUN wget -O MedTagger.zip https://github.com/OHNLP/MedTagger/releases/download/v1.0.9/MedTagger.zip
+RUN unzip MedTagger.zip
+RUN cp /app/work/MedTagger/MedTagger.jar /app/MedTaggerREST/libs
+RUN git clone https://github.com/OHNLP/MedTaggerRESTPlugin.git
+WORKDIR /app/work/MedTaggerRESTPlugin
+RUN mvn clean install -DskipTests
+RUN cp target/MedTaggerRESTPlugin.jar /app/MedTaggerREST/plugins/MedTaggerRESTPlugin.jar
+RUN cp /app/N3CMedTagger/src/main/resources/uima-stream-server-conf.json /app/MedTaggerREST/medtagger_rest_config.json
 
 EXPOSE 8080:8080
 
+WORKDIR /app/N3CMedTagger
+
 RUN -d java -jar /app/MedTaggerREST/UIMA-REST-SERVER.jar -Dserver.port=8080
 RUN rm -r /app/work
-
-WORKDIR /app/N3CMedTagger
 
 RUN mvn clean install -DskipTests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM maven:3.5-jdk-8-alpine
+RUN apk add --no-cache git
 RUN mkdir -p /app/N3CMedTagger
 COPY . /app/N3CMedTagger
 RUN mkdir -p /app/work

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN cp /app/N3CMedTagger/src/main/resources/uima-stream-server-conf.json /app/Me
 EXPOSE 8080:8080
 
 WORKDIR /app/N3CMedTagger
-RUN chmod +X docker_run.sh
+RUN chmod +x docker_run.sh
 
 RUN rm -r /app/work
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,11 @@ WORKDIR /app/work/MedTagger
 RUN wget -O MedTagger.zip https://github.com/OHNLP/MedTagger/releases/download/v1.0.9/MedTagger.zip
 RUN unzip MedTagger.zip
 RUN cp MedTagger.jar /app/MedTaggerREST/libs
-WORKDIR /app/work
-RUN git clone https://github.com/OHNLP/MedTaggerRESTPlugin.git
+RUN mkdir -p /app/work/MedTaggerRESTPlugin
 WORKDIR /app/work/MedTaggerRESTPlugin
-RUN mvn clean install -DskipTests
-RUN cp /app/work/MedTaggerRESTPlugin/target/MedTaggerRESTPlugin.jar /app/MedTaggerREST/plugins/MedTaggerRESTPlugin.jar
+RUN wget -O MedTaggerRESTPlugin.zip https://github.com/OHNLP/MedTaggerRESTPlugin/releases/download/v1.0.1/MedTaggerRESTPlugin.zip
+RUN unzip MedTaggerRESTPlugin.zip
+RUN cp /app/work/MedTaggerRESTPlugin/plugins/MedTaggerRESTPlugin.jar /app/MedTaggerREST/plugins/MedTaggerRESTPlugin.jar
 RUN cp /app/N3CMedTagger/src/main/resources/uima-stream-server-conf.json /app/MedTaggerREST/medtagger_rest_config.json
 
 EXPOSE 8080:8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,33 @@
 FROM maven:3.5-jdk-8-alpine
-COPY . /app 
-WORKDIR /app
+RUN mkdir -p /app/N3CMedTagger \
+    cp -r . /app/N3CMedTagger
+    mkdir -p /app/work
+
+WORKDIR /app/work
+
+RUN git clone https://github.com/OHNLP/UIMA-Stream-Server \
+    cd /app/work/UIMA-Stream-Server \
+    mvn clean install -DskipTests -P EXECUTABLE \
+    mkdir -p /app/MedTaggerREST \
+    cp UIMA-Server-REST/target/UIMA-REST-SERVER.jar /app/MedTaggerREST/UIMA-REST-SERVER.jar \
+    mkdir -p /app/MedTaggerREST/libs \
+    mkdir -p /app/MedTaggerREST/plugins\
+    cd /app/work/ \
+    wget -O MedTagger.zip https://github.com/OHNLP/MedTagger/releases/download/v1.0.9/MedTagger.zip \
+    unzip MedTagger.zip \
+    cp /app/work/MedTagger/MedTagger.jar /app/MedTaggerREST/libs \
+    git clone https://github.com/OHNLP/MedTaggerRESTPlugin.git \
+    cd MedTaggerRESTPlugin \
+    mvn clean install -DskipTests \
+    cp target/MedTaggerRESTPlugin.jar /app/MedTaggerREST/plugins/MedTaggerRESTPlugin.jar \
+    cp /app/N3CMedTagger/src/main/resources/uima-stream-server-conf.json /app/MedTaggerREST/medtagger_rest_config.json
+
+EXPOSE 8080:8080
+
+RUN -d java -jar /app/MedTaggerREST/UIMA-REST-SERVER.jar -Dserver.port=8080
+RUN rm -r /app/work
+
+WORKDIR /app/N3CMedTagger
 
 RUN mvn clean install -DskipTests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3.5-jdk-8-alpine
 RUN mkdir -p /app/N3CMedTagger \
-    cp -r . /app/N3CMedTagger
+    cp -r . /app/N3CMedTagger \
     mkdir -p /app/work
 
 WORKDIR /app/work

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN git clone https://github.com/OHNLP/UIMA-Stream-Server
 WORKDIR /app/work/UIMA-Stream-Server
 RUN mvn clean install -DskipTests -P EXECUTABLE
 RUN mkdir -p /app/MedTaggerREST
-COPY UIMA-Server-REST/target/UIMA-REST-SERVER.jar /app/MedTaggerREST/UIMA-REST-SERVER.jar
+COPY ./UIMA-Server-REST/target/UIMA-REST-SERVER.jar /app/MedTaggerREST/UIMA-REST-SERVER.jar
 RUN mkdir -p /app/MedTaggerREST/libs
 RUN mkdir -p /app/MedTaggerREST/plugins
 WORKDIR /app/work/
@@ -20,7 +20,7 @@ COPY /app/work/MedTagger/MedTagger.jar /app/MedTaggerREST/libs
 RUN git clone https://github.com/OHNLP/MedTaggerRESTPlugin.git
 WORKDIR /app/work/MedTaggerRESTPlugin
 RUN mvn clean install -DskipTests
-COPY target/MedTaggerRESTPlugin.jar /app/MedTaggerREST/plugins/MedTaggerRESTPlugin.jar
+COPY ./target/MedTaggerRESTPlugin.jar /app/MedTaggerREST/plugins/MedTaggerRESTPlugin.jar
 COPY /app/N3CMedTagger/src/main/resources/uima-stream-server-conf.json /app/MedTaggerREST/medtagger_rest_config.json
 
 EXPOSE 8080:8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,18 +10,18 @@ RUN git clone https://github.com/OHNLP/UIMA-Stream-Server
 WORKDIR /app/work/UIMA-Stream-Server
 RUN mvn clean install -DskipTests -P EXECUTABLE
 RUN mkdir -p /app/MedTaggerREST
-COPY /app/work/UIMA-Stream-Server/UIMA-Server-REST/target/UIMA-REST-SERVER.jar /app/MedTaggerREST/UIMA-REST-SERVER.jar
+RUN cp /app/work/UIMA-Stream-Server/UIMA-Server-REST/target/UIMA-REST-SERVER.jar /app/MedTaggerREST/UIMA-REST-SERVER.jar
 RUN mkdir -p /app/MedTaggerREST/libs
 RUN mkdir -p /app/MedTaggerREST/plugins
 WORKDIR /app/work/
 RUN wget -O MedTagger.zip https://github.com/OHNLP/MedTagger/releases/download/v1.0.9/MedTagger.zip
 RUN unzip MedTagger.zip
-COPY /app/work/MedTagger/MedTagger.jar /app/MedTaggerREST/libs
+RUN cp /app/work/MedTagger/MedTagger.jar /app/MedTaggerREST/libs
 RUN git clone https://github.com/OHNLP/MedTaggerRESTPlugin.git
 WORKDIR /app/work/MedTaggerRESTPlugin
 RUN mvn clean install -DskipTests
-COPY /app/work/MedTaggerRESTPlugin/target/MedTaggerRESTPlugin.jar /app/MedTaggerREST/plugins/MedTaggerRESTPlugin.jar
-COPY /app/N3CMedTagger/src/main/resources/uima-stream-server-conf.json /app/MedTaggerREST/medtagger_rest_config.json
+RUN cp /app/work/MedTaggerRESTPlugin/target/MedTaggerRESTPlugin.jar /app/MedTaggerREST/plugins/MedTaggerRESTPlugin.jar
+RUN cp /app/N3CMedTagger/src/main/resources/uima-stream-server-conf.json /app/MedTaggerREST/medtagger_rest_config.json
 
 EXPOSE 8080:8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,12 @@ RUN mkdir -p /app/MedTaggerREST
 RUN cp /app/work/UIMA-Stream-Server/UIMA-Server-REST/target/UIMA-REST-SERVER.jar /app/MedTaggerREST/UIMA-REST-SERVER.jar
 RUN mkdir -p /app/MedTaggerREST/libs
 RUN mkdir -p /app/MedTaggerREST/plugins
-WORKDIR /app/work/
+RUN mkdir -p /app/work/MedTagger
+WORKDIR /app/work/MedTagger
 RUN wget -O MedTagger.zip https://github.com/OHNLP/MedTagger/releases/download/v1.0.9/MedTagger.zip
 RUN unzip MedTagger.zip
-RUN cp /app/work/MedTagger/MedTagger.jar /app/MedTaggerREST/libs
+RUN cp MedTagger.jar /app/MedTaggerREST/libs
+WORKDIR /app/work
 RUN git clone https://github.com/OHNLP/MedTaggerRESTPlugin.git
 WORKDIR /app/work/MedTaggerRESTPlugin
 RUN mvn clean install -DskipTests

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ EXPOSE 8080:8080
 
 WORKDIR /app/N3CMedTagger
 
-RUN nohup java -jar /app/MedTaggerREST/UIMA-REST-SERVER.jar -Dserver.port=8080
+RUN nohup bash -c "java -jar /app/MedTaggerREST/UIMA-REST-SERVER.jar -Dserver.port=8080 &"
 RUN rm -r /app/work
 
 RUN mvn clean install -DskipTests

--- a/MedTaggerWeb.iml
+++ b/MedTaggerWeb.iml
@@ -14,6 +14,15 @@
     <facet type="Spring" name="Spring">
       <configuration />
     </facet>
+    <facet type="web" name="Web">
+      <configuration>
+        <webroots />
+        <sourceRoots>
+          <root url="file://$MODULE_DIR$/src/main/java" />
+          <root url="file://$MODULE_DIR$/src/main/resources" />
+        </sourceRoots>
+      </configuration>
+    </facet>
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
     <output url="file://$MODULE_DIR$/target/classes" />
@@ -180,6 +189,13 @@
     <orderEntry type="library" name="Maven: org.apache.santuario:xmlsec:2.1.4" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.woodstox:woodstox-core:5.0.3" level="project" />
     <orderEntry type="library" name="Maven: org.codehaus.woodstox:stax2-api:3.1.4" level="project" />
+    <orderEntry type="library" name="Maven: jakarta.xml.bind:jakarta.xml.bind-api:2.3.2" level="project" />
+    <orderEntry type="library" name="Maven: jakarta.activation:jakarta.activation-api:1.2.1" level="project" />
+    <orderEntry type="library" name="Maven: org.glassfish.jaxb:jaxb-runtime:2.3.2" level="project" />
+    <orderEntry type="library" name="Maven: org.glassfish.jaxb:txw2:2.3.2" level="project" />
+    <orderEntry type="library" name="Maven: com.sun.istack:istack-commons-runtime:3.0.8" level="project" />
+    <orderEntry type="library" name="Maven: org.jvnet.staxex:stax-ex:1.8.1" level="project" />
+    <orderEntry type="library" name="Maven: com.sun.xml.fastinfoset:FastInfoset:1.2.16" level="project" />
     <orderEntry type="library" name="Maven: javax.servlet:javax.servlet-api:3.1.0" level="project" />
   </component>
 </module>

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,0 +1,2 @@
+screen -dmS UIMA-REST java -jar /app/MedTaggerREST/UIMA-REST-SERVER.jar -Dserver.port=8080
+mvn spring-boot:run

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,3 +1,5 @@
-screen -dmS UIMA-REST java -jar /app/MedTaggerREST/UIMA-REST-SERVER.jar -Dserver.port=8080
+cd /app/MedTaggerREST/
+screen -dmS UIMA-REST java -jar UIMA-REST-SERVER.jar -Dserver.port=8080
+cd /app/N3CNLP
 screen -dmS N3CNLP mvn spring-boot:run
 /bin/bash

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,5 +1,4 @@
 cd /app/MedTaggerREST/
 screen -dmS UIMA-REST java -jar UIMA-REST-SERVER.jar -Dserver.port=8080
-cd /app/N3CNLP
-screen -dmS N3CNLP mvn spring-boot:run
-/bin/bash
+cd /app/N3CMedTagger
+mvn spring-boot:run

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,2 +1,3 @@
 screen -dmS UIMA-REST java -jar /app/MedTaggerREST/UIMA-REST-SERVER.jar -Dserver.port=8080
-mvn spring-boot:run
+screen -dmS N3CNLP mvn spring-boot:run
+/bin/bash

--- a/src/main/java/org/ohnlp/medtagger/ie/util/ResourceUtilManager.java
+++ b/src/main/java/org/ohnlp/medtagger/ie/util/ResourceUtilManager.java
@@ -23,10 +23,7 @@
  *******************************************************************************/
 package org.ohnlp.medtagger.ie.util;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -50,12 +47,12 @@ import org.apache.log4j.Logger;
  * functionality such as file system access and some private members.
  *
  */
-public class ResourceUtilManager {
+public class ResourceUtilManager implements Serializable {
 
-	public static String RESOURCEDIR;
-	private static ResourceUtilManager INSTANCE = null;
+	public transient static String RESOURCEDIR;
+	private transient static ResourceUtilManager INSTANCE = null;
 	
-	private Logger iv_logger = Logger.getLogger(getClass().getName());
+	private transient Logger iv_logger = Logger.getLogger(getClass().getName());
 	
 	private Pattern regexpPattern = Pattern.compile("(.*)");
 	private Pattern normPattern = Pattern.compile("^(.*?)\t(.*?)$");
@@ -74,18 +71,7 @@ public class ResourceUtilManager {
 		return ResourceUtilManager.INSTANCE;
 	}
 
-	ClassLoader classLoader = null;
-	
 	public ResourceUtilManager(String resourcedir) {
-		try {
-			Class cls = Class.forName("org.ohnlp.medtagger.ie.util.ResourceUtilManager");
-			classLoader = cls.getClassLoader();
-		}catch (ClassNotFoundException e){
-			e.printStackTrace();
-		}
-
-		// returns the ClassLoader object associated with this Class
-
 		RESOURCEDIR = resourcedir;
 		readResources(readResourcesFiles("norm"), normPattern, "norm");
 		readResources(readResourcesFiles("regexp"), regexpPattern, "regexp");

--- a/src/main/java/org/ohnlp/n3c/N3CNLPEngine.java
+++ b/src/main/java/org/ohnlp/n3c/N3CNLPEngine.java
@@ -50,6 +50,26 @@ public class N3CNLPEngine {
         throw new UnsupportedOperationException("Deprecated Functionality");
     }
 
+    public JSONAnnotation getJSONAnnotation(String docText) {
+        ObjectNode req = JsonNodeFactory.instance.objectNode();
+        req.put("streamName", "n3c");
+        req.put("metadata", this.rulesPackaged);
+        req.put("document", docText);
+        req.set("serializers", JsonNodeFactory.instance.arrayNode().add("medtagger"));
+        ServerResponse resp = restClient.postForObject(this.restEndpoint, req, ServerResponse.class);
+        List<MedTaggerRESTPluginResponseAnnotation> anns = null;
+        try {
+            anns = new ObjectMapper().readValue(resp.getContent().get("medtagger").toString()
+                    , new TypeReference<List<MedTaggerRESTPluginResponseAnnotation>>() {
+                    });
+        } catch (IOException e) {
+            e.printStackTrace();
+            anns = Collections.emptyList();
+        }
+        return JSONAnnotation.generateConceptMentionBratJson(anns);
+
+    }
+
     public JSONObject getResultJSON(String docText) {
         ObjectNode req = JsonNodeFactory.instance.objectNode();
         req.put("streamName", "n3c");

--- a/src/main/java/org/ohnlp/n3c/N3CNLPEngine.java
+++ b/src/main/java/org/ohnlp/n3c/N3CNLPEngine.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.SerializationUtils;
 import org.json.simple.JSONObject;
 import org.ohnlp.medtagger.ie.util.ResourceUtilManager;
+import org.ohnlp.util.ZipUtil;
 import org.ohnlp.web.JSONAnnotation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,8 +43,7 @@ public class N3CNLPEngine {
     private void initUIMAModel(String ruleDir){
         Path ruleDirPath = Paths.get(ruleDir);
         logger.info("IE Rules:\t" + ruleDirPath.toAbsolutePath());
-        ResourceUtilManager rum = new ResourceUtilManager(ruleDirPath.toString());
-        this.rulesPackaged = Base64.getEncoder().encodeToString(SerializationUtils.serialize(rum));
+        this.rulesPackaged = Base64.getEncoder().encodeToString(ZipUtil.getZippedResourcesFromPath(ruleDirPath));
     }
 
     public HashMap<String, Collection> getResultMap(String docText) {

--- a/src/main/java/org/ohnlp/util/ZipUtil.java
+++ b/src/main/java/org/ohnlp/util/ZipUtil.java
@@ -1,0 +1,34 @@
+package org.ohnlp.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public class ZipUtil {
+    public static byte[] getZippedResourcesFromPath(Path p) {
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream(); ZipOutputStream zip = new ZipOutputStream(bos)) {
+            Files.walk(p).filter(path -> !Files.isDirectory(path))
+                    .forEach(path -> {
+                        ZipEntry ze = new ZipEntry(p.relativize(path).toString());
+                        try {
+                            zip.putNextEntry(ze);
+                            Files.copy(path, zip);
+                            zip.closeEntry();
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                        }
+                    });
+            zip.finish();
+            zip.flush();
+            bos.flush();
+            return bos.toByteArray();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return new byte[0];
+        }
+    }
+}

--- a/src/main/java/org/ohnlp/web/JSONAnnotation.java
+++ b/src/main/java/org/ohnlp/web/JSONAnnotation.java
@@ -4,7 +4,10 @@ import org.apache.uima.jcas.tcas.Annotation;
 import org.json.simple.JSONArray;
 import org.ohnlp.medtagger.type.ConceptMention;
 import org.ohnlp.medtime.type.MedTimex3;
+import org.ohnlp.n3c.N3CNLPEngine;
+
 import java.util.Collection;
+import java.util.List;
 
 public class JSONAnnotation {
     public JSONArray getCmList() {
@@ -44,7 +47,7 @@ public class JSONAnnotation {
      * @param cms List of Annotation from UIMA
      * @return list of JSON array for Brat to display in the html template
      */
-    public static JSONAnnotation generateConceptMentionBratJson(final Collection<Annotation> cms) {
+    public static JSONAnnotation generateConceptMentionBratJson(final List<N3CNLPEngine.MedTaggerRESTPluginResponseAnnotation> cms) {
         JSONArray cmList = new JSONArray();
         JSONArray attribList = new JSONArray();
 
@@ -56,8 +59,7 @@ public class JSONAnnotation {
             return new JSONAnnotation(cmList, attribList);
         }
 
-        for (Annotation annot: cms) {
-            ConceptMention cm = (ConceptMention) annot;
+        for (N3CNLPEngine.MedTaggerRESTPluginResponseAnnotation cm : cms) {
             // Format: [${ID}, ${TYPE}, [[${START}, ${END}]]]
             // note that range of the offsets are [${START},${END})
             // ref:
@@ -70,17 +72,18 @@ public class JSONAnnotation {
 
             // detectionMethod: "DictionaryLookup"
             // detectionMethod: "Matched"
-            if (cm.getDetectionMethod().equals("Matched")) {
-                entityProperties.add("Regex");
-            } else if (cm.getDetectionMethod().equals("DictionaryLookup")) {
-                entityProperties.add("Dict");
-            } else {
-                entityProperties.add("Other");
-            }
+//            if (cm.getDetectionMethod().equals("Matched")) {
+//                entityProperties.add("Regex");
+//            } else if (cm.getDetectionMethod().equals("DictionaryLookup")) {
+//                entityProperties.add("Dict");
+//            } else {
+//                entityProperties.add("Other");
+//            }
+            entityProperties.add("Regex");
             JSONArray spans = new JSONArray();
             JSONArray tokenBeginEnd = new JSONArray();
-            tokenBeginEnd.add(cm.getBegin());
-            tokenBeginEnd.add(cm.getEnd());
+            tokenBeginEnd.add(cm.getMatch_start());
+            tokenBeginEnd.add(cm.getMatch_end());
             spans.add(tokenBeginEnd);
             entityProperties.add(spans);
             cmList.add(entityProperties);
@@ -95,7 +98,7 @@ public class JSONAnnotation {
             attribProperties.add(String.format("A%d", attribIdInt++));
             attribProperties.add("norm");
             attribProperties.add(bratEntityId);
-            attribProperties.add(cm.getNormTarget());
+            attribProperties.add(cm.getConcept_code());
             attribList.add(attribProperties);
 
             JSONArray certaintyProperties = new JSONArray();

--- a/src/main/java/org/ohnlp/web/WebServiceController.java
+++ b/src/main/java/org/ohnlp/web/WebServiceController.java
@@ -258,18 +258,17 @@ public class WebServiceController {
             webInputText = new WebInputText("test post login");
         }
 
-        HashMap<String, Collection> annotMap = n3CNLPEngine.getResultMap(webInputText.getDocText());
 
         // render template for the fields in index-template
         ModelAndView indexView = new ModelAndView();
         indexView.setViewName("index-template");
         indexView.addObject("input_text", webInputText.getDocText());
         logger.info(String.format("Input for submit \"%s\"", webInputText.getDocText()));
-        logger.info(String.format("Output map \"%s\"", annotMap));
+//        logger.info(String.format("Output map \"%s\"", annotMap));
 
         // get a list of concepts as JSON list to feed into the template
 
-        JSONAnnotation jsAnnot = JSONAnnotation.generateConceptMentionBratJson(annotMap.get("cm"));
+        JSONAnnotation jsAnnot = n3CNLPEngine.getJSONAnnotation(webInputText.getDocText());
 
         indexView.addObject("cmList", jsAnnot.getCmList());
         indexView.addObject("attribList", jsAnnot.getAttribList());

--- a/src/main/resources/uima-stream-server-conf.json
+++ b/src/main/resources/uima-stream-server-conf.json
@@ -1,0 +1,8 @@
+{
+  "pipelines": [
+    {
+      "id": "n3c",
+      "path": "dynamic"
+    }
+  ]
+}


### PR DESCRIPTION
Changes:
- Dockerfile deployment: downloads UIMA-Stream-Server and MedTaggerRESTPlugin and does appropriate compilation and installation steps. Boots an instance at http://localhost:8080
- N3CNLPEngine now requests (CM only for this commit) NLP Artifacts from the localhost:8080 instance instead

TODO prior to merge
- Look at incorporating TIMEx3, possibly as a separate NLP pipeline plugin
- @ymnliu Maybe more appropriate to just use SUTIME? Since that is what we are going with in Backbone.